### PR TITLE
removed uiwebview references in jason code

### DIFF
--- a/xcode/Jasonette/Components/html/JasonHtmlComponent.h
+++ b/xcode/Jasonette/Components/html/JasonHtmlComponent.h
@@ -7,5 +7,5 @@
 #import "JasonComponent.h"
 #import "Jason.h"
 
-@interface JasonHtmlComponent : JasonComponent
+@interface JasonHtmlComponent : JasonComponent <WKNavigationDelegate>
 @end

--- a/xcode/Jasonette/Components/html/JasonHtmlComponent.m
+++ b/xcode/Jasonette/Components/html/JasonHtmlComponent.m
@@ -5,11 +5,32 @@
 //  Copyright © 2016 gliechtenstein. All rights reserved.
 //
 #import "JasonHtmlComponent.h"
+#import "JasonLogger.h"
+
 
 @implementation JasonHtmlComponent
-+ (UIView *)build:(UIWebView *)component withJSON:(NSDictionary *)json withOptions:(NSDictionary *)options {
++ (UIView *)build:(WKWebView *)component withJSON:(NSDictionary *)json withOptions:(NSDictionary *)options {
+    
     if (!component) {
-        component = [[UIWebView alloc] initWithFrame:CGRectZero];
+        
+        WKWebViewConfiguration * config = [[WKWebViewConfiguration alloc] init];
+        
+        [config setAllowsInlineMediaPlayback:YES];
+        
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        
+        if ([config respondsToSelector:@selector(setMediaPlaybackRequiresUserAction:)]) {
+            [config setMediaPlaybackRequiresUserAction:NO];
+        }
+        
+#pragma clang diagnostic pop
+        
+        if (@available(iOS 10, *)) {
+            [config setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+        }
+        
+        
         CGFloat width = [[UIScreen mainScreen] bounds].size.width;
         CGFloat height = [[UIScreen mainScreen] bounds].size.height;
 
@@ -22,31 +43,78 @@
                 height = [JasonHelper pixelsInDirection:@"vertical" fromExpression:json[@"style"][@"height"]];
             }
         }
+        
+       
+        // TODO: Figure it out what this does
+        NSString * summon = @"var JASON={call: function(e){var n=document.createElement(\"IFRAME\");n.setAttribute(\"src\",\"jason:\"+JSON.stringify(e)),document.documentElement.appendChild(n),n.parentNode.removeChild(n),n=null}};";
+        
+        WKUserScript * summonScript = [[WKUserScript alloc] initWithSource:summon injectionTime:WKUserScriptInjectionTimeAtDocumentEnd forMainFrameOnly:YES];
+        
+        WKUserContentController * controller = [WKUserContentController new];
+        [controller addUserScript:summonScript];
 
+        config.userContentController = controller;
+        
         CGRect frame = CGRectMake (0, 0, width, height);
-        component = [[UIWebView alloc] initWithFrame:frame];
+        component = [[WKWebView alloc] initWithFrame:frame configuration:config];
+        
+        component.translatesAutoresizingMaskIntoConstraints = NO;
+        component.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+        component.navigationDelegate = [self self];
     }
 
     component.opaque = NO;
     component.backgroundColor = [UIColor clearColor];
 
     if (json[@"text"] && ![[NSNull null] isEqual:json[@"text"]]) {
+        
+        // Remember to add <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+        // if you want to display properly
         NSString * html = [json[@"text"] description];
-        [((UIWebView *)component) loadHTMLString:html baseURL:nil];
+        NSString * lowerCaseHtml = [html lowercaseString];
+        
+        if(![lowerCaseHtml containsString:@"viewport"] && ![lowerCaseHtml
+             containsString:@"initial-scale"])
+        {
+            DTLogWarning(@"html <meta name='viewport'> not found. Display could be not properly rendered in html component. Forcing initial-scale=1.0.");
+            
+            NSRange headRange = [[html lowercaseString] rangeOfString:@"<head>"];
+            DTLogDebug(@"Range location %d length %d", headRange.location, headRange.length);
+
+            if(headRange.location != NSNotFound) {
+                
+                NSString * head = [[html substringToIndex:headRange.location] stringByAppendingString:@"<meta name='viewport' content='width=device-width, initial-scale=1.0'>"];
+                
+                DTLogDebug(@"Head", head);
+                
+                NSString * body = [html substringFromIndex:(headRange.location + @"<head>".length)];
+                
+                DTLogDebug(@"Body", body);
+                
+                html = [NSString stringWithFormat:@"%@%@", head, body];
+            }
+            
+        }
+        
+        DTLogDebug(@"Rendering HTML Component %@", html);
+        
+        [component loadHTMLString:html baseURL:nil];
+        
         component.scrollView.scrollEnabled = NO;
 
-        component.delegate = [self self];
+        //component.delegate = [self self];
         [self stylize:json component:component];
     }
 
     // allow autoplay
-    component.mediaPlaybackRequiresUserAction = NO;
+    //component.mediaPlaybackRequiresUserAction = NO;
 
     // allow inline playback
-    component.allowsInlineMediaPlayback = YES;
+    //component.allowsInlineMediaPlayback = YES;
 
     // user interaction enable/disable => disabled by default
     component.userInteractionEnabled = NO;
+    
 
     if (json[@"action"]) {
         // if there's an 'action' attribute, delegate the event handling to this component
@@ -72,34 +140,42 @@
 }
 
 + (void)actionButtonClicked:(UIButton *)sender {
-    NSLog (@"sender.payload = %@", sender.payload);
+    DTLogDebug(@"sender.payload = %@", sender.payload);
 
     if (sender.payload && sender.payload[@"action"]) {
         [[Jason client] call:sender.payload[@"action"]];
     }
 }
 
-+ (void)webViewDidFinishLoad:(UIWebView *)webView
-{
-    NSString * summon = @"var JASON={call: function(e){var n=document.createElement(\"IFRAME\");n.setAttribute(\"src\",\"jason:\"+JSON.stringify(e)),document.documentElement.appendChild(n),n.parentNode.removeChild(n),n=null}};";
+// TODO: Check if these two methods are used at all.
 
-    [webView stringByEvaluatingJavaScriptFromString:summon];
-}
-
-+ (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
-    if ([[[request URL] absoluteString] hasPrefix:@"jason:"]) {
-        // Extract the selector name from the URL
-        NSString * json = [[[request URL] absoluteString] substringFromIndex:6];
-        json = [json stringByRemovingPercentEncoding];
-
-        NSData * data = [json dataUsingEncoding:NSUTF8StringEncoding];
-        NSDictionary * action = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-        [[Jason client] call:action];
-
-        return NO;
-    }
-
-    return YES;
-}
+//+ (void)webViewDidFinishLoad:(WKWebView *)webView
+//{
+//    NSString * summon = @"var JASON={call: function(e){var n=document.createElement(\"IFRAME\");n.setAttribute(\"src\",\"jason:\"+JSON.stringify(e)),document.documentElement.appendChild(n),n.parentNode.removeChild(n),n=null}};";
+//
+//    //[webView stringByEvaluatingJavaScriptFromString:summon];
+//    [webView evaluateJavaScript:summon completionHandler:^(id _Nullable result, NSError * _Nullable error) {
+//        DTLogDebug(@"%@", result);
+//        if(error){
+//            DTLogWarning(@"%@", error);
+//        }
+//    }];
+//}
+//
+//+ (BOOL)webView:(WKWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
+//    if ([[[request URL] absoluteString] hasPrefix:@"jason:"]) {
+//        // Extract the selector name from the URL
+//        NSString * json = [[[request URL] absoluteString] substringFromIndex:6];
+//        json = [json stringByRemovingPercentEncoding];
+//
+//        NSData * data = [json dataUsingEncoding:NSUTF8StringEncoding];
+//        NSDictionary * action = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+//        [[Jason client] call:action];
+//
+//        return NO;
+//    }
+//
+//    return YES;
+//}
 
 @end

--- a/xcode/Jasonette/Core/Jason/Jason.h
+++ b/xcode/Jasonette/Core/Jason/Jason.h
@@ -27,7 +27,7 @@
 
 @import MediaPlayer;
 
-@interface Jason : NSObject <UINavigationControllerDelegate, UIImagePickerControllerDelegate, UITabBarControllerDelegate, UIWebViewDelegate>
+@interface Jason : NSObject <UINavigationControllerDelegate, UIImagePickerControllerDelegate, UITabBarControllerDelegate>
 
 @property (strong, nonatomic) NSDictionary * parser;
 @property (strong, nonatomic) NSDictionary * data;


### PR DESCRIPTION
This replaces UIWebview from Jason core since it will be deprecated. But some dependencies still use it and it will be difficult to know if apple will be detecting those uses in the libs.

If this happens then maybe a complete rewrite of the core would be needed with other dependencies that does not use UIWebView.