### PR TITLE
Vision scanning kills applications

### DIFF
--- a/xcode/Jasonette/Services/$vision/JasonVisionService.m
+++ b/xcode/Jasonette/Services/$vision/JasonVisionService.m
@@ -47,6 +47,8 @@
     if (![JasonMemory client].executing) {
         for (AVMetadataObject * metadata in metadataObjects) {
             AVMetadataMachineReadableCodeObject * transformed = (AVMetadataMachineReadableCodeObject *)metadata;
+            if (![transformed isKindOfClass:[AVMetadataMachineReadableCodeObject class]])
+                return;
             self.is_open = NO;
             [[Jason client] call:events[@"$vision.onscan"]
                             with:@{


### PR DESCRIPTION
I have an application using Vision API and it crashes suddenly when:

- Opening the camera on iPhone 13 (as far as I know this is the first phone failing just when opening the camera. At least it fails when not pointing a QR code before opening the camera or without covering the camera with a finger.)
- Pointing to a face, dog, cat or any interesting object iOS camera can recognize.

All phones have the same and latest iOS version today.

The problem with iPhone 13 is that when it tests the recognized object it returns an AVMetadataSalientObject when the camera captures something. Lower iPhone versions with the same iOS version don't do that. But all phones crash when pointing any "interesting" object for iOS like Faces (returning AVMetadataFaceObject) and so. All these objects don't have a stringValue property. 
